### PR TITLE
sdn-cdi geonetwok plugin bugfixes

### DIFF
--- a/src/main/plugin/iso19139.sdn-cdi/schema-ident.xml
+++ b/src/main/plugin/iso19139.sdn-cdi/schema-ident.xml
@@ -5,6 +5,7 @@
 	<name>iso19139.sdn-cdi</name>
 	<id>5495f7a0-14e3-49ad-8814-5aa9b892a8f4</id>
 	<version>1.0</version>
+	<appMinorVersionSupported>3.4.0</appMinorVersionSupported>
 	<depends>iso19139</depends>
 	<!-- Profile XSD location -->
 	<schemaLocation>http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd 

--- a/src/main/plugin/iso19139.sdn-cdi/templates/CDI_ISO19139_full_example.xml
+++ b/src/main/plugin/iso19139.sdn-cdi/templates/CDI_ISO19139_full_example.xml
@@ -180,7 +180,7 @@
                   </gmd:referenceSystemIdentifier>
                </gmd:MD_ReferenceSystem>
             </gmd:referenceSystemInfo>
-         <gmd:metadataExtensionInfo xlink:href="http://schemas.seadatanet.org/Standards-Software/Metadata-formats/extensionInformation.xml"/>
+         <gmd:metadataExtensionInfo xlink:href="http://schemas.seadatanet.org/Standards-Software/Metadata-formats/cdiExtensionInformation.xml"/>
 		   <gmd:identificationInfo>
 			  <gmd:MD_DataIdentification>
 				 <gmd:citation>


### PR DESCRIPTION
I had to make these changes for this schema plugin to work with Geonetwork versions later than 3.4.0 (specifically 3.10.10 which includes the log4j2 patch)